### PR TITLE
연락처관리 UI [STEP 1] iyeah, Jenna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,95 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## DS_Store
+*.DS_Store
+
+## User settings
+xcuserdata/
+xcuserdata/*
+*.xcuserstate
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/ios-cantact-manager/ContactManagerUI/AppDelegate.swift
+++ b/ios-cantact-manager/ContactManagerUI/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  ContactManagerUI
+//
+//  Created by J.E on 2023/01/30.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ios-cantact-manager/ContactManagerUI/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios-cantact-manager/ContactManagerUI/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-cantact-manager/ContactManagerUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-cantact-manager/ContactManagerUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-cantact-manager/ContactManagerUI/Assets.xcassets/Contents.json
+++ b/ios-cantact-manager/ContactManagerUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-cantact-manager/ContactManagerUI/Base.lproj/LaunchScreen.storyboard
+++ b/ios-cantact-manager/ContactManagerUI/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios-cantact-manager/ContactManagerUI/Base.lproj/Main.storyboard
+++ b/ios-cantact-manager/ContactManagerUI/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios-cantact-manager/ContactManagerUI/Info.plist
+++ b/ios-cantact-manager/ContactManagerUI/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios-cantact-manager/ContactManagerUI/SceneDelegate.swift
+++ b/ios-cantact-manager/ContactManagerUI/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  ContactManagerUI
+//
+//  Created by J.E on 2023/01/30.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ios-cantact-manager/ContactManagerUI/ViewController.swift
+++ b/ios-cantact-manager/ContactManagerUI/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  ContactManagerUI
+//
+//  Created by J.E on 2023/01/30.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.pbxproj
+++ b/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B4BC7962987619800C21130 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4BC7952987619800C21130 /* AppDelegate.swift */; };
+		3B4BC7982987619800C21130 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4BC7972987619800C21130 /* SceneDelegate.swift */; };
+		3B4BC79A2987619800C21130 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4BC7992987619800C21130 /* ViewController.swift */; };
+		3B4BC79D2987619800C21130 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B4BC79B2987619800C21130 /* Main.storyboard */; };
+		3B4BC79F2987619A00C21130 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B4BC79E2987619A00C21130 /* Assets.xcassets */; };
+		3B4BC7A22987619A00C21130 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B4BC7A02987619A00C21130 /* LaunchScreen.storyboard */; };
+		3B4BC7A7298761A500C21130 /* InputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA122952C861002C7E4D /* InputManager.swift */; };
+		3B4BC7A8298761A700C21130 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA142952C8F1002C7E4D /* Profile.swift */; };
+		3B4BC7A9298761AA00C21130 /* ContactManageSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */; };
+		3B4BC7AA298761AC00C21130 /* InputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1AE1922953F044003C94B0 /* InputError.swift */; };
+		3B4BC7AB298761AC00C21130 /* OutputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB374D09295AC31800A737ED /* OutputManager.swift */; };
 		3B7DEA132952C861002C7E4D /* InputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA122952C861002C7E4D /* InputManager.swift */; };
 		3B7DEA152952C8F1002C7E4D /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA142952C8F1002C7E4D /* Profile.swift */; };
 		3B7DEA172952D10D002C7E4D /* ContactManageSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */; };
@@ -28,6 +39,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3B4BC7932987619700C21130 /* ContactManagerUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManagerUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B4BC7952987619800C21130 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		3B4BC7972987619800C21130 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		3B4BC7992987619800C21130 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		3B4BC79C2987619800C21130 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		3B4BC79E2987619A00C21130 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3B4BC7A12987619A00C21130 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3B4BC7A32987619A00C21130 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3B7DEA122952C861002C7E4D /* InputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputManager.swift; sourceTree = "<group>"; };
 		3B7DEA142952C8F1002C7E4D /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
 		3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactManageSystem.swift; sourceTree = "<group>"; };
@@ -38,6 +57,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3B4BC7902987619700C21130 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB5EB1A32952BE4300752155 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -48,10 +74,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3B4BC7942987619800C21130 /* ContactManagerUI */ = {
+			isa = PBXGroup;
+			children = (
+				3B4BC7952987619800C21130 /* AppDelegate.swift */,
+				3B4BC7972987619800C21130 /* SceneDelegate.swift */,
+				3B4BC7992987619800C21130 /* ViewController.swift */,
+				3B4BC79B2987619800C21130 /* Main.storyboard */,
+				3B4BC79E2987619A00C21130 /* Assets.xcassets */,
+				3B4BC7A02987619A00C21130 /* LaunchScreen.storyboard */,
+				3B4BC7A32987619A00C21130 /* Info.plist */,
+			);
+			path = ContactManagerUI;
+			sourceTree = "<group>";
+		};
 		EB5EB19D2952BE4300752155 = {
 			isa = PBXGroup;
 			children = (
 				EB5EB1A82952BE4300752155 /* ios-cantact-manager */,
+				3B4BC7942987619800C21130 /* ContactManagerUI */,
 				EB5EB1A72952BE4300752155 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -60,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				EB5EB1A62952BE4300752155 /* ios-cantact-manager */,
+				3B4BC7932987619700C21130 /* ContactManagerUI.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -80,6 +122,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3B4BC7922987619700C21130 /* ContactManagerUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3B4BC7A62987619A00C21130 /* Build configuration list for PBXNativeTarget "ContactManagerUI" */;
+			buildPhases = (
+				3B4BC78F2987619700C21130 /* Sources */,
+				3B4BC7902987619700C21130 /* Frameworks */,
+				3B4BC7912987619700C21130 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ContactManagerUI;
+			productName = ContactManagerUI;
+			productReference = 3B4BC7932987619700C21130 /* ContactManagerUI.app */;
+			productType = "com.apple.product-type.application";
+		};
 		EB5EB1A52952BE4300752155 /* ios-cantact-manager */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EB5EB1AD2952BE4300752155 /* Build configuration list for PBXNativeTarget "ios-cantact-manager" */;
@@ -107,6 +166,9 @@
 				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1420;
 				TargetAttributes = {
+					3B4BC7922987619700C21130 = {
+						CreatedOnToolsVersion = 14.2;
+					};
 					EB5EB1A52952BE4300752155 = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -126,11 +188,40 @@
 			projectRoot = "";
 			targets = (
 				EB5EB1A52952BE4300752155 /* ios-cantact-manager */,
+				3B4BC7922987619700C21130 /* ContactManagerUI */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		3B4BC7912987619700C21130 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B4BC7A22987619A00C21130 /* LaunchScreen.storyboard in Resources */,
+				3B4BC79F2987619A00C21130 /* Assets.xcassets in Resources */,
+				3B4BC79D2987619800C21130 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		3B4BC78F2987619700C21130 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B4BC7A7298761A500C21130 /* InputManager.swift in Sources */,
+				3B4BC7AA298761AC00C21130 /* InputError.swift in Sources */,
+				3B4BC7AB298761AC00C21130 /* OutputManager.swift in Sources */,
+				3B4BC7A8298761A700C21130 /* Profile.swift in Sources */,
+				3B4BC7A9298761AA00C21130 /* ContactManageSystem.swift in Sources */,
+				3B4BC79A2987619800C21130 /* ViewController.swift in Sources */,
+				3B4BC7962987619800C21130 /* AppDelegate.swift in Sources */,
+				3B4BC7982987619800C21130 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EB5EB1A22952BE4300752155 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -146,7 +237,85 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXVariantGroup section */
+		3B4BC79B2987619800C21130 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3B4BC79C2987619800C21130 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		3B4BC7A02987619A00C21130 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3B4BC7A12987619A00C21130 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		3B4BC7A42987619A00C21130 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManagerUI/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jenna.ContactManagerUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3B4BC7A52987619A00C21130 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManagerUI/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jenna.ContactManagerUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		EB5EB1AB2952BE4300752155 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -283,6 +452,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3B4BC7A62987619A00C21130 /* Build configuration list for PBXNativeTarget "ContactManagerUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3B4BC7A42987619A00C21130 /* Debug */,
+				3B4BC7A52987619A00C21130 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		EB5EB1A12952BE4300752155 /* Build configuration list for PBXProject "ios-cantact-manager" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.pbxproj
+++ b/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.pbxproj
@@ -1,0 +1,307 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3B7DEA132952C861002C7E4D /* InputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA122952C861002C7E4D /* InputManager.swift */; };
+		3B7DEA152952C8F1002C7E4D /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA142952C8F1002C7E4D /* Profile.swift */; };
+		3B7DEA172952D10D002C7E4D /* ContactManageSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */; };
+		EB1AE1932953F044003C94B0 /* InputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1AE1922953F044003C94B0 /* InputError.swift */; };
+		EB374D0A295AC31800A737ED /* OutputManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB374D09295AC31800A737ED /* OutputManager.swift */; };
+		EB5EB1AA2952BE4300752155 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5EB1A92952BE4300752155 /* main.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		EB5EB1A42952BE4300752155 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		3B7DEA122952C861002C7E4D /* InputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputManager.swift; sourceTree = "<group>"; };
+		3B7DEA142952C8F1002C7E4D /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
+		3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactManageSystem.swift; sourceTree = "<group>"; };
+		EB1AE1922953F044003C94B0 /* InputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputError.swift; sourceTree = "<group>"; };
+		EB374D09295AC31800A737ED /* OutputManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputManager.swift; sourceTree = "<group>"; };
+		EB5EB1A62952BE4300752155 /* ios-cantact-manager */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "ios-cantact-manager"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB5EB1A92952BE4300752155 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		EB5EB1A32952BE4300752155 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		EB5EB19D2952BE4300752155 = {
+			isa = PBXGroup;
+			children = (
+				EB5EB1A82952BE4300752155 /* ios-cantact-manager */,
+				EB5EB1A72952BE4300752155 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		EB5EB1A72952BE4300752155 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EB5EB1A62952BE4300752155 /* ios-cantact-manager */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EB5EB1A82952BE4300752155 /* ios-cantact-manager */ = {
+			isa = PBXGroup;
+			children = (
+				EB5EB1A92952BE4300752155 /* main.swift */,
+				3B7DEA122952C861002C7E4D /* InputManager.swift */,
+				3B7DEA142952C8F1002C7E4D /* Profile.swift */,
+				3B7DEA162952D10D002C7E4D /* ContactManageSystem.swift */,
+				EB1AE1922953F044003C94B0 /* InputError.swift */,
+				EB374D09295AC31800A737ED /* OutputManager.swift */,
+			);
+			path = "ios-cantact-manager";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		EB5EB1A52952BE4300752155 /* ios-cantact-manager */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EB5EB1AD2952BE4300752155 /* Build configuration list for PBXNativeTarget "ios-cantact-manager" */;
+			buildPhases = (
+				EB5EB1A22952BE4300752155 /* Sources */,
+				EB5EB1A32952BE4300752155 /* Frameworks */,
+				EB5EB1A42952BE4300752155 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-cantact-manager";
+			productName = "ios-cantact-manager";
+			productReference = EB5EB1A62952BE4300752155 /* ios-cantact-manager */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EB5EB19E2952BE4300752155 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1420;
+				LastUpgradeCheck = 1420;
+				TargetAttributes = {
+					EB5EB1A52952BE4300752155 = {
+						CreatedOnToolsVersion = 14.2;
+					};
+				};
+			};
+			buildConfigurationList = EB5EB1A12952BE4300752155 /* Build configuration list for PBXProject "ios-cantact-manager" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EB5EB19D2952BE4300752155;
+			productRefGroup = EB5EB1A72952BE4300752155 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EB5EB1A52952BE4300752155 /* ios-cantact-manager */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EB5EB1A22952BE4300752155 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB374D0A295AC31800A737ED /* OutputManager.swift in Sources */,
+				3B7DEA132952C861002C7E4D /* InputManager.swift in Sources */,
+				3B7DEA152952C8F1002C7E4D /* Profile.swift in Sources */,
+				3B7DEA172952D10D002C7E4D /* ContactManageSystem.swift in Sources */,
+				EB5EB1AA2952BE4300752155 /* main.swift in Sources */,
+				EB1AE1932953F044003C94B0 /* InputError.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		EB5EB1AB2952BE4300752155 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		EB5EB1AC2952BE4300752155 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		EB5EB1AE2952BE4300752155 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		EB5EB1AF2952BE4300752155 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		EB5EB1A12952BE4300752155 /* Build configuration list for PBXProject "ios-cantact-manager" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB5EB1AB2952BE4300752155 /* Debug */,
+				EB5EB1AC2952BE4300752155 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EB5EB1AD2952BE4300752155 /* Build configuration list for PBXNativeTarget "ios-cantact-manager" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EB5EB1AE2952BE4300752155 /* Debug */,
+				EB5EB1AF2952BE4300752155 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = EB5EB19E2952BE4300752155 /* Project object */;
+}

--- a/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios-cantact-manager/ios-cantact-manager.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios-cantact-manager/ios-cantact-manager.xcodeproj/xcshareddata/xcschemes/ios-cantact-manager.xcscheme
+++ b/ios-cantact-manager/ios-cantact-manager.xcodeproj/xcshareddata/xcschemes/ios-cantact-manager.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EB5EB1A52952BE4300752155"
+               BuildableName = "ios-cantact-manager"
+               BlueprintName = "ios-cantact-manager"
+               ReferencedContainer = "container:ios-cantact-manager.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB5EB1A52952BE4300752155"
+            BuildableName = "ios-cantact-manager"
+            BlueprintName = "ios-cantact-manager"
+            ReferencedContainer = "container:ios-cantact-manager.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB5EB1A52952BE4300752155"
+            BuildableName = "ios-cantact-manager"
+            BlueprintName = "ios-cantact-manager"
+            ReferencedContainer = "container:ios-cantact-manager.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-cantact-manager/ios-cantact-manager/ContactManageSystem.swift
+++ b/ios-cantact-manager/ios-cantact-manager/ContactManageSystem.swift
@@ -1,0 +1,101 @@
+//
+//  ContactManageSystem.swift
+//  ios-cantact-manager
+//
+//  Created by J.E on 2022/12/21.
+//
+
+import Foundation
+
+struct ContactManageSystem {
+    let inputManager = InputManager()
+    var profiles = Set<Profile>()
+    var isFinished = false
+    
+    enum Menu: String {
+        case addProfile = "1"
+        case listUpProfile = "2"
+        case searchProfile = "3"
+        case stop = "x"
+    }
+    
+    mutating func run() {
+        while !isFinished {
+            do {
+                let input = try menuInputValue()
+                pipeInMenu(input)
+                print()
+            } catch {
+                OutputManager.print(text: .invalidMenu)
+            }
+        }
+    }
+    
+    func menuInputValue() throws -> String {
+        OutputManager.print(text: .inputMenu)
+        let menuInput = try inputManager.menuInput()
+        
+        return menuInput
+    }
+    
+    mutating func pipeInMenu(_ input: String) {
+        guard let input = Menu(rawValue: input) else {
+            OutputManager.print(text: .invalidMenu)
+            return
+        }
+        switch input {
+        case .addProfile:
+            addProfile()
+        case .listUpProfile:
+            listUpProfile()
+        case .searchProfile:
+            searchProfile()
+        case .stop:
+            stop()
+        }
+    }
+    
+    mutating func addProfile() {
+        do {
+            OutputManager.print(text: .inputInfo)
+            let inputArray = try inputManager.parseUserInput()
+            let (name, age ,tel) = (inputArray[0], inputArray[1], inputArray[2])
+            try inputManager.checkUserInput(name, age, tel)
+            let profile = Profile(name: name, age: age, tel: tel)
+            profiles.insert(profile)
+            OutputManager.print(profile: profile)
+        } catch InputError.invalidInput {
+            OutputManager.print(text: .invalidInput)
+        } catch InputError.invalidAge {
+            OutputManager.print(text: .invalidAge)
+        } catch InputError.invalidTel {
+            OutputManager.print(text: .invalidTel)
+        } catch {
+            OutputManager.print(text: .invalidInput)
+        }
+    }
+    
+    private func listUpProfile() {
+        OutputManager.print(profiles: profiles)
+    }
+    
+    private func searchProfile() {
+        do {
+            OutputManager.print(text: .inputProfileName)
+            let targetName = try inputManager.targetInput()
+            let filteredProfileData = profiles.filter { $0.name == targetName }
+            guard !filteredProfileData.isEmpty else {
+                OutputManager.printNoMatchingData(name: targetName)
+                return
+            }
+            OutputManager.print(profiles: filteredProfileData)
+        } catch {
+            OutputManager.print(text: .invalidInput)
+        }
+    }
+    
+    mutating func stop() {
+        OutputManager.print(text: .stopSystem)
+        isFinished = true
+    }
+}

--- a/ios-cantact-manager/ios-cantact-manager/ContactManageSystem.swift
+++ b/ios-cantact-manager/ios-cantact-manager/ContactManageSystem.swift
@@ -60,7 +60,7 @@ struct ContactManageSystem {
             OutputManager.print(text: .inputInfo)
             let inputArray = try inputManager.parseUserInput()
             let (name, age ,tel) = (inputArray[0], inputArray[1], inputArray[2])
-            try inputManager.checkUserInput(name, age, tel)
+            try inputManager.verifyUserInput(name, age, tel)
             let profile = Profile(name: name, age: age, tel: tel)
             profiles.insert(profile)
             OutputManager.print(profile: profile)

--- a/ios-cantact-manager/ios-cantact-manager/ContactManager.swift
+++ b/ios-cantact-manager/ios-cantact-manager/ContactManager.swift
@@ -1,0 +1,24 @@
+//
+//  contactManager.swift
+//  ios-cantact-manager
+//
+//  Created by J.E on 2022/12/28.
+//
+
+//import Foundation
+//
+//struct ContactManager {
+//    var contactManageSystem = ContactManageSystem()
+//
+//    mutating func run() {
+//        while !contactManageSystem.isFinished {
+//            do {
+//                let input = try contactManageSystem.menuInputValue()
+//                contactManageSystem.pipeInMenu(input)
+//                print()
+//            } catch {
+//                OutputManager.print(text: .invalidMenu)
+//            }
+//        }
+//    }
+//}

--- a/ios-cantact-manager/ios-cantact-manager/InputError.swift
+++ b/ios-cantact-manager/ios-cantact-manager/InputError.swift
@@ -1,0 +1,14 @@
+//
+//  ErrorManage.swift
+//  ios-cantact-manager
+//
+//  Created by 조용현 on 2022/12/22.
+//
+
+import Foundation
+
+enum InputError: Error {
+    case invalidAge
+    case invalidTel
+    case invalidInput
+}

--- a/ios-cantact-manager/ios-cantact-manager/InputError.swift
+++ b/ios-cantact-manager/ios-cantact-manager/InputError.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum InputError: Error {
+    case invalidName
     case invalidAge
     case invalidTel
     case invalidInput

--- a/ios-cantact-manager/ios-cantact-manager/InputManager.swift
+++ b/ios-cantact-manager/ios-cantact-manager/InputManager.swift
@@ -1,0 +1,64 @@
+//
+//  InputManager.swift
+//  ios-cantact-manager
+//
+//  Created by J.E on 2022/12/21.
+//
+
+import Foundation
+
+struct InputManager {
+    private let splitInputCount = 3
+    private let hyphenCount = 2
+    
+    func menuInput() throws -> String {
+        let input = readLine()
+        guard let input = input else {
+            throw InputError.invalidInput
+        }
+        
+        return input
+    }
+    
+    func parseUserInput() throws -> [String] {
+        let input = readLine()
+        guard let input = input, input != "" else {
+            throw InputError.invalidInput
+        }
+        
+        let splitInput = input.components(separatedBy: "/").map {
+            $0.replacingOccurrences(of: " ", with: "")
+        }
+        guard splitInput.count == splitInputCount else {
+            throw InputError.invalidInput
+        }
+        
+        return splitInput
+    }
+    
+    func checkUserInput(_ name: String, _ age: String, _ tel: String) throws {
+        let ageRegex = "^[0-9]{1,3}$"
+        let ageRegexTest = NSPredicate(format: "SELF MATCHES %@", ageRegex)
+        guard ageRegexTest.evaluate(with: age) else {
+            throw InputError.invalidAge
+        }
+        
+        guard (tel.filter { $0 == "-" }).count == hyphenCount else {
+            throw InputError.invalidTel
+        }
+        let filteredTel = tel.filter { $0 != "-" }
+        let telRegex = "^[0-9]{9,}$"
+        let telRegexTest = NSPredicate(format: "SELF MATCHES %@", telRegex)
+        guard telRegexTest.evaluate(with: filteredTel) else {
+            throw InputError.invalidTel
+        }
+    }
+    
+    func targetInput() throws -> String {
+        let input = readLine()
+        guard let input = input else {
+            throw InputError.invalidInput
+        }
+        return input
+    }
+}

--- a/ios-cantact-manager/ios-cantact-manager/InputManager.swift
+++ b/ios-cantact-manager/ios-cantact-manager/InputManager.swift
@@ -10,6 +10,12 @@ import Foundation
 struct InputManager {
     private let splitInputCount = 3
     private let hyphenCount = 2
+
+    enum RegularExpressions: String {
+        case nameChecker = "^[a-zA-Z]*$"
+        case ageChecker = "^[0-9]{1,3}$"
+        case phoneNumberChecker = "^[0-9]{2,3}-[0-9]{3,4}-[0-9]{4}$"
+    }
     
     func menuInput() throws -> String {
         let input = readLine()
@@ -35,25 +41,26 @@ struct InputManager {
         
         return splitInput
     }
-    
-    func checkUserInput(_ name: String, _ age: String, _ tel: String) throws {
-        let ageRegex = "^[0-9]{1,3}$"
-        let ageRegexTest = NSPredicate(format: "SELF MATCHES %@", ageRegex)
-        guard ageRegexTest.evaluate(with: age) else {
+
+    func isValidUserInput(string: String, type: RegularExpressions) -> Bool {
+        let isValid = string.range(of: type.rawValue,  options: .regularExpression) != nil
+        return isValid
+    }
+
+    func verifyUserInput(_ name: String, _ age: String, _ tel: String) throws {
+        guard isValidUserInput(string: name, type: RegularExpressions.nameChecker) else {
+            throw InputError.invalidName
+        }
+
+        guard isValidUserInput(string: age, type: RegularExpressions.ageChecker) else {
             throw InputError.invalidAge
         }
-        
-        guard (tel.filter { $0 == "-" }).count == hyphenCount else {
-            throw InputError.invalidTel
-        }
-        let filteredTel = tel.filter { $0 != "-" }
-        let telRegex = "^[0-9]{9,}$"
-        let telRegexTest = NSPredicate(format: "SELF MATCHES %@", telRegex)
-        guard telRegexTest.evaluate(with: filteredTel) else {
+
+        guard isValidUserInput(string: tel, type: RegularExpressions.phoneNumberChecker) else {
             throw InputError.invalidTel
         }
     }
-    
+
     func targetInput() throws -> String {
         let input = readLine()
         guard let input = input else {

--- a/ios-cantact-manager/ios-cantact-manager/OutputManager.swift
+++ b/ios-cantact-manager/ios-cantact-manager/OutputManager.swift
@@ -1,0 +1,49 @@
+//
+//  OutputManager.swift
+//  ios-cantact-manager
+//
+//  Created by 조용현 on 2022/12/27.
+//
+
+import Foundation
+
+struct OutputManager {
+    enum Text: String, CustomStringConvertible {
+        case inputInfo = "연락처 정보를 입력해주세요 : "
+        case inputMenu = "1) 연락처 추가 2) 연락처 목록보기 3) 연락처 검색 x) 종료\n메뉴를 선택해주세요 : "
+        case invalidMenu = "선택이 잘못되었습니다 확인 후 다시 입력해주세요."
+        case stopSystem = "\n[프로그램 종료]"
+        case invalidInput = "입력한 정보가 잘못되었습니다. 입력 형식을 확인해주세요."
+        case invalidAge = "입력한 나이정보가 잘못되었습니다. 입력 형식을 확인해주세요."
+        case invalidTel = "입력한 연락처정보가 잘못되었습니다. 입력 형식을 확인해주세요."
+        case inputProfileName = "연락처에서 찾을 이름을 입력해주세요 : "
+        
+        var description: String {
+            return self.rawValue
+        }
+    }
+    
+    static func print(text: OutputManager.Text) {
+        switch text {
+        case .inputInfo, .inputMenu, .stopSystem, .inputProfileName:
+            Swift.print(text.description, terminator: "")
+        default:
+            Swift.print(text.description)
+        }
+    }
+    
+    static func print(profile: Profile) {
+        Swift.print("입력한 정보는 \(profile.age)세 \(profile.name)(\(profile.tel))입니다.")
+    }
+    
+    static func print(profiles: Set<Profile>) {
+        profiles.sorted(by: { $0.name < $1.name }).forEach {
+            Swift.print("- \($0.name) / \($0.age) / \($0.tel)")
+        }
+    }
+    
+    static func printNoMatchingData(name: String) {
+        Swift.print("연락처에 \(name) 이(가) 없습니다.")
+    }
+}
+

--- a/ios-cantact-manager/ios-cantact-manager/Profile.swift
+++ b/ios-cantact-manager/ios-cantact-manager/Profile.swift
@@ -1,0 +1,14 @@
+//
+//  Profile.swift
+//  ios-cantact-manager
+//
+//  Created by J.E on 2022/12/21.
+//
+
+import Foundation
+
+struct Profile: Hashable {
+    let name: String
+    let age: String
+    let tel: String
+}

--- a/ios-cantact-manager/ios-cantact-manager/main.swift
+++ b/ios-cantact-manager/ios-cantact-manager/main.swift
@@ -1,0 +1,11 @@
+//
+//  main.swift
+//  ios-cantact-manager
+//
+//  Created by 조용현 on 2022/12/21.
+//
+
+import Foundation
+
+var contactManageSystem = ContactManageSystem()
+contactManageSystem.run()


### PR DESCRIPTION
안녕하세요 Cory !! @corykim0829
이번 연락처관리프로그램(UI ver) 프로젝트를 함께 진행하게 된 iyeah & Jenna입니다 🌱
Step1의 구현 사항은 많지 않아서 간단하게 작성해보았어요!
앞으로 2주 동안 잘 부탁드립니다 🐶
　

## ✅ 구현 사항
- [x]  기존의 연락처 관리 프로그램 프로젝트에 UIKit App Target을 추가
(Target 이름 : ContactManagerUI)
- [x]  ContactManager 타깃의 주요 파일을 ContactManagerUI의 타깃 멤버십 파일로 추가
(main.swift 제외)
　
　
## ✅ 구현 과정
- [x]  취합 및 코드 정리
   - 팀원이 변경되어 각 팀에서 작성했던 코드와 관점을 공유하고 설명하는 과정을 거침
   - 한 팀의 프로젝트를 바탕으로 하되, 다른 팀의 코드에서 좋았던 부분을 가져와 적용 (정규표현식: 커밋주소) 
- [x]  로그 제외한 소스코드 통으로 복사
   - 위의 사유로 커밋 기록은 제외하고 소스코드만 가져옴
- [ ]  폴더링 — 보류
   - 이전까지의 프로젝트와 달리 뷰가 여러 개일 가능성이 큰 점, command line tools를 기반으로 하여 ViewController 외에 main파일이 존재하는 등 고려할 게 많았음
   - 다음 스텝에서 고민해볼 예정
- [ ]  readLine들 대체하기 — 보류
   - 마찬가지로 다음스텝 뷰 구성을 보고 결정할 것

　
## ✅ 고민 사항
- 폴더, 프로젝트 명
   - 기존 프로젝트 코드를 가져오면서, 프로젝트 및 폴더 명을 바꿔야 할지 고민했으나
      - '타겟'에 대해 공부하면서 하나의 타겟은 하나의 프로덕트이며 
      프로젝트 내에 여러 개의(= 별개의) 타겟(프로덕트)이 존재할 수 있다는 점을 알게 되었고, 
      - 즉 타겟`ContactManagerUI`을 새로 추가한다는 것은 프로젝트에 별도의 제품을 만든다는 것이므로, 오히려 이름을 같게 맞추려 할 필요가 없음을 깨달았어요
      - 그래서 프로젝트, 폴더 명은 원래대로 `ios-cantact-manager`로 유지했어요
　
　