### PR TITLE
연락처 관리 앱 [STEP3] JaeHyeok, Dora

### DIFF
--- a/ios-contact-manager-ui/ios-contact-manager-ui/Base.lproj/Main.storyboard
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/Base.lproj/Main.storyboard
@@ -19,9 +19,21 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="FJ5-JD-ClQ">
                                 <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <searchBar key="tableHeaderView" contentMode="redraw" id="9NH-GT-7Ce">
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="56"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                    <scopeButtonTitles>
+                                        <string>Title</string>
+                                        <string>Title</string>
+                                    </scopeButtonTitles>
+                                    <connections>
+                                        <outlet property="delegate" destination="BYZ-38-t0r" id="G2M-Ur-dci"/>
+                                    </connections>
+                                </searchBar>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="cell" textLabel="DzA-lk-glz" detailTextLabel="QmC-Bz-ATn" style="IBUITableViewCellStyleSubtitle" id="God-iG-pJX">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                        <rect key="frame" x="0.0" y="106" width="393" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="God-iG-pJX" id="aaL-MA-NbS">
                                             <rect key="frame" x="0.0" y="0.0" width="362.66666666666669" height="43.666667938232422"/>
@@ -64,6 +76,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="SearchBar" destination="9NH-GT-7Ce" id="EOd-v6-OE2"/>
                         <outlet property="tableView" destination="FJ5-JD-ClQ" id="r24-Ng-Nb2"/>
                         <segue destination="bIj-Df-MAO" kind="presentation" id="MME-fS-GWj"/>
                     </connections>

--- a/ios-contact-manager-ui/ios-contact-manager-ui/Base.lproj/Main.storyboard
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aJa-gv-N0j">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aJa-gv-N0j">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,22 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="FJ5-JD-ClQ">
-                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
-                                <searchBar key="tableHeaderView" contentMode="redraw" id="9NH-GT-7Ce">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="56"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                    <textInputTraits key="textInputTraits"/>
-                                    <scopeButtonTitles>
-                                        <string>Title</string>
-                                        <string>Title</string>
-                                    </scopeButtonTitles>
-                                    <connections>
-                                        <outlet property="delegate" destination="BYZ-38-t0r" id="G2M-Ur-dci"/>
-                                    </connections>
-                                </searchBar>
+                                <rect key="frame" x="0.0" y="159" width="393" height="659"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="cell" textLabel="DzA-lk-glz" detailTextLabel="QmC-Bz-ATn" style="IBUITableViewCellStyleSubtitle" id="God-iG-pJX">
-                                        <rect key="frame" x="0.0" y="106" width="393" height="43.666667938232422"/>
+                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="God-iG-pJX" id="aaL-MA-NbS">
                                             <rect key="frame" x="0.0" y="0.0" width="362.66666666666669" height="43.666667938232422"/>
@@ -58,12 +46,24 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <searchBar contentMode="redraw" id="9NH-GT-7Ce">
+                                <rect key="frame" x="0.0" y="103" width="393" height="56"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <scopeButtonTitles>
+                                    <string>Title</string>
+                                    <string>Title</string>
+                                </scopeButtonTitles>
+                                <connections>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="G2M-Ur-dci"/>
+                                </connections>
+                            </searchBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="FJ5-JD-ClQ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="9Hf-DD-Aiu"/>
-                            <constraint firstItem="FJ5-JD-ClQ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="T54-fx-1zM"/>
+                            <constraint firstItem="FJ5-JD-ClQ" firstAttribute="top" secondItem="9NH-GT-7Ce" secondAttribute="bottom" id="T54-fx-1zM"/>
                             <constraint firstItem="FJ5-JD-ClQ" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Y3v-Cv-e1a"/>
                             <constraint firstItem="FJ5-JD-ClQ" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="hFP-Qf-1JN"/>
                         </constraints>
@@ -83,7 +83,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="65" y="-34"/>
+            <point key="canvasLocation" x="64.885496183206101" y="-34.507042253521128"/>
         </scene>
         <!--New Contact View Controller-->
         <scene sceneID="0I6-8d-fal">

--- a/ios-contact-manager-ui/ios-contact-manager-ui/Model/AddressBook.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/Model/AddressBook.swift
@@ -9,39 +9,27 @@ import Foundation
 
 class AddressBook {
     
-    private var contacts: [[Contact]] = Array(repeating: [], count: 27)
-    private var contactsForDisplay: [[Contact]] = [[Contact]]()
-    
-    func getFirstLetterIndex(_ name: String) -> Int {
-        let firstLetter = Array(name)[0].uppercased()
-        let index = firstLetter.unicodeScalars.map { Int($0.value)}[0]
-        return index >= 65 && index <= 90 ? Int(index - 65) : 26
-    }
-    
+    private var contacts = [Contact]()
+
     func addContact(_ newContact: Contact) {
-        let index = getFirstLetterIndex(newContact.name)
-        contacts[index].append(newContact)
-        contacts[index].sort(by: {$0.name < $1.name})
+        contacts.append(newContact)
+        contacts.sort(by: {$0.name < $1.name})
+    }
+
+    func deleteContact(_ row: Int) {
+        contacts.remove(at: row)
+        
     }
     
-    func deleteContact(_ section: Int, _ row: Int) {
-        contacts[section].remove(at: row)
+    func changeContact(_ row: Int, _ changedContact: Contact) {
+        contacts[row] = changedContact
     }
     
-    func changeContact(_ section: Int, _ row: Int, _ changedContact: Contact) {
-        contacts[section][row] = changedContact
-    }
+    func showContact(_ row: Int) -> Contact {
+        return contacts[row]
+    }                       
     
-    func showContact(_ section: Int, _ row: Int) -> Contact {
-        return contactsForDisplay[section][row]
-    }
-    
-    func getSectionSize() -> Int {
-        contactsForDisplay = contacts.filter{ !$0.isEmpty }
-        return contactsForDisplay.count
-    }
-    
-    func getRowSize(_ section: Int) -> Int {
-        return contactsForDisplay[section].count
+    func getRowSize() -> Int {
+        return contacts.count
     }
 }

--- a/ios-contact-manager-ui/ios-contact-manager-ui/Model/AddressBook.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/Model/AddressBook.swift
@@ -10,15 +10,16 @@ import Foundation
 class AddressBook {
     
     private var contacts = [Contact]()
-
+    private var filteredContacts: [Contact]?
+    private var searchText: String?
+    
     func addContact(_ newContact: Contact) {
         contacts.append(newContact)
         contacts.sort(by: {$0.name < $1.name})
     }
-
+    
     func deleteContact(_ row: Int) {
         contacts.remove(at: row)
-        
     }
     
     func changeContact(_ row: Int, _ changedContact: Contact) {
@@ -26,10 +27,52 @@ class AddressBook {
     }
     
     func showContact(_ row: Int) -> Contact {
+        guard let input = searchText, let filtered = filteredContacts else {
+            return contacts[row]
+        }
+        
+        if filtered.isEmpty && input.isEmpty {
+            return contacts[row]
+        }
+        
+        if !input.isEmpty {
+            return filtered[row]
+        }
+        
         return contacts[row]
-    }                       
+    }
     
     func getRowSize() -> Int {
+        
+        guard let input = searchText, let filtered = filteredContacts else {
+            return contacts.count
+        }
+        
+        if filtered.isEmpty && input.isEmpty {
+            return contacts.count
+        }
+        
+        if !input.isEmpty {
+            return filtered.count
+        }
+        
         return contacts.count
+    }
+    
+    func searchContact(_ input: String) {
+        searchText = input
+        filteredContacts = []
+        
+        for contact in contacts {
+            if contact.name.lowercased().contains(input.lowercased()) {
+                filteredContacts?.append(contact)
+            }
+        }
+        
+        for contact in contacts {
+            if contact.phoneNumber.replacingOccurrences(of: "-", with: "").contains(input.replacingOccurrences(of: "-", with: "")){
+                filteredContacts?.append(contact)
+            }
+        }
     }
 }

--- a/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
@@ -66,7 +66,7 @@ extension NewContactViewController {
         present(alert, animated: true)
     }
     
-    private func saveAlert(_ contact: Contact) {
+    private func showSaveAlert(_ contact: Contact) {
         let text: String = "이름: \(contact.name), \n 나이: \(contact.age), \n 연락처: \(contact.phoneNumber) \n 저장하시겠습니까?"
         let alert = UIAlertController(title: title, message: text, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "예", style: .default, handler: { _ in

--- a/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
@@ -123,7 +123,6 @@ extension NewContactViewController: UITextFieldDelegate {
         
         if range.location == 2 && number.last != "-" {
             number.insert("-", at: number.index(number.startIndex, offsetBy: 2))
-            print(number.count)
         }
         
         if range.location == 6 && number.last != "-" {

--- a/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
@@ -40,26 +40,26 @@ class NewContactViewController: UIViewController {
 
 extension NewContactViewController {
     @IBAction private func tappedCancelButton(_ sender: UIButton) {
-        cancelAlert()
+        showCancelAlert()
     }
     
     @IBAction private func tappedSaveButton(_ sender: UIButton) {
-        guard let name = nameCheck() else {
+        guard let name = checkName() else {
             invalidAlert(invalid: nameTextField)
             return
         }
-        guard let age = ageCheck() else {
+        guard let age = checkAge() else {
             invalidAlert(invalid: ageTextField)
             return
         }
-        guard let number = numberCheck() else {
+        guard let number = checkNumber() else {
             invalidAlert(invalid: phoneNumberTextField)
             return
         }
         saveAlert(Contact(name: name, phoneNumber: number, age: age))
     }
     
-    private func cancelAlert() {
+    private func showCancelAlert() {
         let alert = UIAlertController(title: title, message: "정말 취소하겠습니까?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "예", style: .destructive, handler: { _ in self.dismiss(animated: true)}))
         alert.addAction(UIAlertAction(title: "아니오", style: .default, handler: nil))
@@ -76,21 +76,21 @@ extension NewContactViewController {
         present(alert, animated: true)
     }
     
-    private func nameCheck() -> String? {
+    private func checkName() -> String? {
         guard let name = nameTextField.text else {
             return nil
         }
-        return name == "" ? nil : name.components(separatedBy: " ").joined()
+        return name.isEmpty ? nil : name.components(separatedBy: " ").joined()
     }
     
-    private func ageCheck() -> Int? {
+    private func checkAge() -> Int? {
         guard let ageText = ageTextField.text, let age = Int(ageText) else {
             return nil
         }
         return age
     }
     
-    private func numberCheck() -> String? {
+    private func checkNumber() -> String? {
         guard let number = phoneNumberTextField.text else {
             return nil
         }

--- a/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/NewContactViewController.swift
@@ -26,12 +26,12 @@ class NewContactViewController: UIViewController {
         phoneNumberTextField.delegate = self
     }
     
-    func navigationSetting() {
+    private func navigationSetting() {
         navigationBar.isTranslucent = false
         navigationBar.shadowImage = UIImage()
     }
     
-    func keyboardSetting() {
+    private func keyboardSetting() {
         nameTextField.keyboardType = .namePhonePad
         ageTextField.keyboardType = .numberPad
         phoneNumberTextField.keyboardType = .phonePad
@@ -39,11 +39,11 @@ class NewContactViewController: UIViewController {
 }
 
 extension NewContactViewController {
-    @IBAction func tappedCancelButton(_ sender: UIButton) {
+    @IBAction private func tappedCancelButton(_ sender: UIButton) {
         cancelAlert()
     }
     
-    @IBAction func tappedSaveButton(_ sender: UIButton) {
+    @IBAction private func tappedSaveButton(_ sender: UIButton) {
         guard let name = nameCheck() else {
             invalidAlert(invalid: nameTextField)
             return
@@ -59,14 +59,14 @@ extension NewContactViewController {
         saveAlert(Contact(name: name, phoneNumber: number, age: age))
     }
     
-    func cancelAlert() {
+    private func cancelAlert() {
         let alert = UIAlertController(title: title, message: "정말 취소하겠습니까?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "예", style: .destructive, handler: { _ in self.dismiss(animated: true)}))
         alert.addAction(UIAlertAction(title: "아니오", style: .default, handler: nil))
         present(alert, animated: true)
     }
     
-    func saveAlert(_ contact: Contact) {
+    private func saveAlert(_ contact: Contact) {
         let text: String = "이름: \(contact.name), \n 나이: \(contact.age), \n 연락처: \(contact.phoneNumber) \n 저장하시겠습니까?"
         let alert = UIAlertController(title: title, message: text, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "예", style: .default, handler: { _ in
@@ -76,28 +76,28 @@ extension NewContactViewController {
         present(alert, animated: true)
     }
     
-    func nameCheck() -> String? {
+    private func nameCheck() -> String? {
         guard let name = nameTextField.text else {
             return nil
         }
         return name == "" ? nil : name.components(separatedBy: " ").joined()
     }
     
-    func ageCheck() -> Int? {
+    private func ageCheck() -> Int? {
         guard let ageText = ageTextField.text, let age = Int(ageText) else {
             return nil
         }
         return age
     }
     
-    func numberCheck() -> String? {
+    private func numberCheck() -> String? {
         guard let number = phoneNumberTextField.text else {
             return nil
         }
         return number.count >= 11 && number.filter { $0 == "-" }.count == 2 ? number : nil
     }
     
-    func invalidAlert(invalid: UITextField) {
+    private func invalidAlert(invalid: UITextField) {
         var text: String
         
         switch invalid {

--- a/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
@@ -10,9 +10,9 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
-    @IBOutlet weak var SearchBar: UISearchBar!
+    @IBOutlet weak var searchBar: UISearchBar!
     
-   private let cellIdentifier: String = "cell"
+    private let cellIdentifier: String = "cell"
     var addressBook: AddressBook  = AddressBook()
     
     
@@ -20,13 +20,11 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
         initialSetting()
-        addressBook.addContact(Contact(name: "mond", phoneNumber: "010-0000-0000", age: 100))
-        addressBook.addContact(Contact(name: "dora", phoneNumber: "010-0000-0000", age: 100))
-        addressBook.addContact(Contact(name: "bora", phoneNumber: "010-0000-0000", age: 100))
     }
     
     private func initialSetting() {
         self.tableView.dataSource = self
+        self.searchBar.delegate = self
     }
 }
 
@@ -64,5 +62,13 @@ extension ViewController {
 extension ViewController: SendDelegate {
     func sendContact(newContact: Contact) {
         self.addressBook.addContact(newContact)
+        tableView.reloadData()
+    }
+}
+
+extension ViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        addressBook.searchContact(searchText)
+        tableView.reloadData()
     }
 }

--- a/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
@@ -15,7 +15,6 @@ class ViewController: UIViewController {
     private let cellIdentifier: String = "cell"
     var addressBook: AddressBook  = AddressBook()
     
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -29,15 +28,14 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: UITableViewDataSource {
-        
-     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         addressBook.getRowSize()
     }
     
-     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
         let contactData: Contact = addressBook.showContact( indexPath.row)
-        
         cell.textLabel?.text = contactData.name + "(\(contactData.age))"
         cell.detailTextLabel?.text = contactData.phoneNumber
         return cell
@@ -46,7 +44,9 @@ extension ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             addressBook.deleteContact(indexPath.row)
-            tableView.deleteRows(at: [indexPath], with: .automatic)
+            defer {
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+            }
         }
     }
 }

--- a/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
+++ b/ios-contact-manager-ui/ios-contact-manager-ui/ViewController.swift
@@ -10,43 +10,51 @@ import UIKit
 class ViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var SearchBar: UISearchBar!
     
-    var cellIdentifier: String = "cell"
+   private let cellIdentifier: String = "cell"
     var addressBook: AddressBook  = AddressBook()
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         initialSetting()
+        addressBook.addContact(Contact(name: "mond", phoneNumber: "010-0000-0000", age: 100))
+        addressBook.addContact(Contact(name: "dora", phoneNumber: "010-0000-0000", age: 100))
+        addressBook.addContact(Contact(name: "bora", phoneNumber: "010-0000-0000", age: 100))
     }
     
-    func initialSetting() {
+    private func initialSetting() {
         self.tableView.dataSource = self
     }
 }
 
 extension ViewController: UITableViewDataSource {
-    
-    func numberOfSections(in tableView: UITableView) -> Int {
-        addressBook.getSectionSize()
+        
+     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        addressBook.getRowSize()
     }
     
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        addressBook.getRowSize(section)
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-        let contactData: Contact = addressBook.showContact(indexPath.section, indexPath.row)
+        let contactData: Contact = addressBook.showContact( indexPath.row)
         
         cell.textLabel?.text = contactData.name + "(\(contactData.age))"
         cell.detailTextLabel?.text = contactData.phoneNumber
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            addressBook.deleteContact(indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+        }
+    }
 }
 
 extension ViewController {
-    @IBAction func TappedAddButton(_ sender: UIBarButtonItem) {
+    @IBAction private func TappedAddButton(_ sender: UIBarButtonItem) {
         guard let newContactViewController = storyboard?.instantiateViewController(withIdentifier: "NewContactViewController") as? NewContactViewController else { return }
         newContactViewController.delegate = self
         self.present(newContactViewController, animated: true)
@@ -56,6 +64,5 @@ extension ViewController {
 extension ViewController: SendDelegate {
     func sendContact(newContact: Contact) {
         self.addressBook.addContact(newContact)
-        self.tableView.reloadData()
     }
 }


### PR DESCRIPTION
리뷰어: @zdodev
버드: @KSK9820, @SimJaeHyeok

## 소대, 안녕하세요! [STEP 3] PR 드립니다🙌🏻

## Summary ⛳️

### 구현 기능 및 상세

- 필수 테이블뷰의 셀을 스와이프하여 삭제하는 메뉴를 보이고, 실제로 삭제할 수 있습니다.
- 검색기능 통해 연락처 목록 내의 특정 연락처만 테이블뷰에 남길 수 있습니다.
---

### 고려했던 점 👀
- 색인 이상의 의미가 없어진 2차원 배열의 데이터 모델을 1차원 데이터 모델로 수정하며, 해당 수정에 따른 로직들도 함께 수정하였습니다.
- 테이블 뷰에 연락처를 추가하고 삭제하는 과정에서의 오버헤드에 대해 고려했습니다.
    - 연락처를 하나만 삭제하는 과정에서 tableView.reloadDate()는 큰 낭비라고 판단했습니다.
    - 이 오버헤드를 줄이는 방법으로 deleteRows와 deleteRows에 대해 찾아보았고, 둘의 차이에 대해서 공부하였습니다.
    - 결론적으로, deleteRows는 테이블 뷰의 데이터 소스에서 업데이트 이전 값에서 연산한 값(1)과 업데이트 이후의 값(2)이 서로 동일하면 오류가 발생하고, 
    - reloadRows는 업데이트 이전 값(1)과 업데이트 이후 값(2)이 다르다면 오류가 발생하였습니다. 
    - 또한, 이 둘 메서드를 사용할 때 tableview는 테이블 뷰의 행의 개수를 항상 체크하는 것으로 결론 지었습니다.
    - 해당 결론과 과정에 다시 짚어보거나 잘 못된 부분이 있는지 알고 싶습니다.
---

### 질문 사항
- 의존성에 대해서 질문드리고 싶습니다.
    - UISearchBar의 입력 값에 따른 테이블 뷰의 화면을 네 가지로 분류하였습니다.
    - 아무것도 입력하지 않은 초기 화면, searchText가 있고 결과값이 있는 경우와 없는 경우, searchText를 입력하고 지우고 난 후, 이외
    - 이를 인지하려면 searchBar에 현재 text의 유무를 파악해야해서, 이를 외부 전역 변수에 저장하고 다른 함수에서 사용하였습니다.
    - 이렇기 때문에 의존성이 높아지게 됩니다. 이를 피하고자 하는 다른 방법이 있을까요?
- 접근제어자 `interna`l과 `public`의 차이를 잘 모르겠습니다.
    - `internal`과  `private`는 접근에 관한 명확한 차이가 있는데, `internal`과 `public`의 명확한 차이를 모르겠습니다. `internal`의 경우 하나의 모듈에서 접근이 가능하고, public의 경우는 모듈 외부에서 접근 가능하다고 나와있는데  어느 범위인지 알고 싶습니다.